### PR TITLE
Add CSS Validation Workflow

### DIFF
--- a/.github/workflows/validate-css-html.yml
+++ b/.github/workflows/validate-css-html.yml
@@ -1,11 +1,11 @@
-name: HTML Check
+name: HTML & CSS Check
 
 on:
   push:
 
 # Example from https://github.com/Cyb3r-Jak3/html5validator-action/wiki/Getting-Started
 jobs:
-  build:
+  html-css-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2 # Required with all actions

--- a/.github/workflows/validate-css-html.yml
+++ b/.github/workflows/validate-css-html.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-hub/stylelint@master
         env:
-          PATTERN: "*.css"
+          PATTERN: "public/css/*.css"
           INDENT_SPACES: 4
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-css-html.yml
+++ b/.github/workflows/validate-css-html.yml
@@ -5,20 +5,15 @@ on:
 
 # Example from https://github.com/Cyb3r-Jak3/html5validator-action/wiki/Getting-Started
 jobs:
-  linters: 
-    name: stylelint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: nok-ko/stylelint-csstree-validator-action@nok-ko-patch-csstree
-        env:
-          PATTERN: "public/css/*.css"
-          INDENT_SPACES: 4
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2 # Requried with all actions
+    - uses: actions/checkout@v2 # Required with all actions
     - name: Checks HTML5
       uses: Cyb3r-Jak3/html5validator-action@v7.1.1
       with:
         root: html/
+    - name: Validates CSS
+      uses: nok-ko/validate-css-action@main
+      with:
+        directory: public/css

--- a/.github/workflows/validate-css-html.yml
+++ b/.github/workflows/validate-css-html.yml
@@ -5,6 +5,15 @@ on:
 
 # Example from https://github.com/Cyb3r-Jak3/html5validator-action/wiki/Getting-Started
 jobs:
+  linters: 
+    name: stylelint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-hub/stylelint@master
+        env:
+          PATTERN: "*.css"
+          INDENT_SPACES: 4
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate-css-html.yml
+++ b/.github/workflows/validate-css-html.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-hub/stylelint@master
+      - uses: nok-ko/stylelint-csstree-validator-action@nok-ko-patch-csstree
         env:
           PATTERN: "public/css/*.css"
           INDENT_SPACES: 4

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "stylelint-csstree-validator"
+  ],
+  "rules": {
+    "csstree/validator": true
+  }
+}

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    "stylelint-csstree-validator"
-  ],
-  "rules": {
-    "csstree/validator": true
-  }
-}


### PR DESCRIPTION
## What This PR Does
- [x] Adds a CSS Validation GitHub workflow – every commit will be validated for CSS errors using the `csstree-validator` Node package.

## Why This Is Good
- Adds confidence that we haven't seriously mucked up any CSS, hopefully avoiding Arron's wrath.

## Why This Might Be Bad
- Adds extra spam to the already pretty high traffic `#commit-log` channel in our team Discord.
    - I can make the commit bot not report action runs if the spam is too much to bear.
- Based on a semi-janky custom GitHub Action (see [`nok-ko/validate-css-action`](https://github.com/nok-ko/validate-css-action))