### PR TITLE
Add supporting code for deploys to `shakeguard.nokko.me`

### DIFF
--- a/deploy/DEPLOYING.md
+++ b/deploy/DEPLOYING.md
@@ -1,0 +1,17 @@
+# How to deploy ShakeGuard
+
+Currently the deploy-to-production-server workflow is highly manual. The steps
+are as follows:
+
+* Log into the server via SSH.
+* `cd` into the directory `/var/www/`.
+* There may already be a Git repo at `/var/www/shakeguard`, if so, just `sudo git checkout` whichever branch you want to deploy.
+    * Otherwise, `sudo git clone https://github.com/ShakeGuard/2800-202210-BBY06 /var/www/shakeguard` to clone the repo.
+* `cd /var/www/shakeguard`, then run `npm ci` to install the packages from `package-lock.json`.
+* This `deploy/` directory contains the systemd `shakeguard.service` file that 
+is used to set the app running on a production server.
+* Copy the `.service` file to `/etc/systemd/system/shakeguard.service`.
+* Run `sudo systemctl daemon-reload` to update `systemd`'s configuration.
+* Run `sudo systemctl start shakeguard.service` to start the service.
+* Check that the service has started successfully with the command `systemctl status shakeguard.service`
+    * If the service failed to start, check for errors with `journalctl -u shakeguard.service`.

--- a/deploy/shakeguard.service
+++ b/deploy/shakeguard.service
@@ -2,6 +2,8 @@
 Description=ShakeGuard
 
 [Service]
+# Copy .secrets directory from the reference location.
+ExecStartPre=cp -r /home/shakeguard/.secrets/ /var/www/shakeguard/.secrets/
 ExecStart=/var/www/shakeguard/main.js -i localhost -p 27017 --db shakeguard --auth true
 Restart=always
 User=nobody

--- a/deploy/shakeguard.service
+++ b/deploy/shakeguard.service
@@ -4,7 +4,7 @@ Description=ShakeGuard
 [Service]
 # Copy .secrets directory from the reference location.
 ExecStartPre=cp -r /home/shakeguard/.secrets/ /var/www/shakeguard/.secrets/
-ExecStart=/var/www/shakeguard/main.js -i localhost -p 27017 --db shakeguard --auth true
+ExecStart=/var/www/shakeguard/main.js -i localhost -p 27017 --db shakeguard --auth true --port 8082
 Restart=always
 User=nobody
 Group=nogroup

--- a/deploy/shakeguard.service
+++ b/deploy/shakeguard.service
@@ -3,14 +3,15 @@ Description=ShakeGuard
 
 [Service]
 # Copy .secrets directory from the reference location.
-ExecStartPre=cp -r /home/shakeguard/.secrets/ /var/www/shakeguard/.secrets/
+ExecStartPre=rm -rf /var/www/shakeguard/.secrets
+ExecStartPre=cp -r /home/shakeguard/.secrets /var/www/shakeguard/.secrets
+WorkingDirectory=/var/www/shakeguard
 ExecStart=/var/www/shakeguard/main.js -i localhost -p 27017 --db shakeguard --auth true --port 8082
 Restart=always
-User=nobody
-Group=nogroup
+User=shakeguard
+Group=shakeguard
 Environment=PATH=/usr/bin:/usr/local/bin
 Environment=NODE_ENV=production
-WorkingDirectory=/var/www/shakeguard
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/shakeguard.service
+++ b/deploy/shakeguard.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ShakeGuard
+
+[Service]
+ExecStart=/var/www/shakeguard/main.js -i localhost -p 27017 --db shakeguard --auth true
+Restart=always
+User=nobody
+Group=nogroup
+Environment=PATH=/usr/bin:/usr/local/bin
+Environment=NODE_ENV=production
+WorkingDirectory=/var/www/shakeguard
+
+[Install]
+WantedBy=multi-user.target

--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+#!/usr/bin/node
 "use strict";
 
 import { MongoClient } from 'mongodb';

--- a/main.js
+++ b/main.js
@@ -21,6 +21,11 @@ console.error = () => {};
 const secrets = await readSecrets();
 
 const argv = yargs(hideBin(process.argv))
+  .option('port', {
+	  alias: 'P',
+	  description: "The port that the app should listen on.",
+	  type: 'number'
+  })
   .option('instanceAddress', {
     alias: 'i',
     description: "The IP address or hostname of the MongoDB instance to connect the app to. Defaults to `localhost`.",
@@ -272,7 +277,7 @@ app.post("/signup", async (req, res) => {
 })
 
 // RUN SERVER
-let port = 8000;
+const port = argv.port ?? 8000;
 app.listen(port, function () {
   console.log(`Server listening on http://localhost:${port}`);
 })


### PR DESCRIPTION
## Why?

Assignment 02b requires us to deploy our webapp to a hosting service. (I've decided to stick with my tiny server at `db.nokko.me`.) To make this happen, I'm adding some supporting code to the repo.

## What?
- [x] Adds a `shakeguard.service` `systemd` service file.
    - [x] Now tested: app is live on `shakeguard.nokko.me`.
    - Internally, the Node.js server listens on port 8082, but an nginx config passes traffic to `shakeguard.nokko.me:80` and `shakeguard.nokko.me:443` to Express.
    - [ ] TODO: put the `nginx` config file for the site into the repository, for documentation purposes…
- [x] Adds a [“shebang” line](https://en.wikipedia.org/wiki/Shebang_(Unix)) to the head of `main.js`.
- [x] (Possibly) adds a script to copy the `shakeguard.service` file to `/etc/systemd/system/` on the production server.
- [x] Adds a `--port` command-line option that makes the server listen for requests on a different port.