### PR TITLE
Split workflow tasks.

### DIFF
--- a/.github/workflows/validate-css.yml
+++ b/.github/workflows/validate-css.yml
@@ -1,0 +1,14 @@
+name: Validate CSS
+
+on:
+  push:
+
+jobs:
+  html-css-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Validates CSS
+      uses: nok-ko/validate-css-action@main
+      with:
+        directory: public/css

--- a/.github/workflows/validate-html.yml
+++ b/.github/workflows/validate-html.yml
@@ -1,4 +1,4 @@
-name: HTML & CSS Check
+name: Validate HTML
 
 on:
   push:
@@ -13,7 +13,3 @@ jobs:
       uses: Cyb3r-Jak3/html5validator-action@v7.1.1
       with:
         root: html/
-    - name: Validates CSS
-      uses: nok-ko/validate-css-action@main
-      with:
-        directory: public/css


### PR DESCRIPTION
Simple PR, splits the CSS and HTML validators apart, now they're two separate workflows.

Before, if anything in the HTML was awry, GitHub actions would not complain about invalid CSS. Now, it should run the two checks separately, and report the results of both in all cases.