### PR TITLE
Use MongoDB session store instead of the default Express store

### DIFF
--- a/main.js
+++ b/main.js
@@ -63,7 +63,7 @@ const dbName = argv.dbName ?? "COMP2800";
 
 // Log in 'dev' format to stdout, if devLog option is set.
 // If devLog is not set, log errors only to stdout.
-await new Promise((resolve) => {
+const secrets = await new Promise((resolve) => {
 	if (argv.devLog) {
 		app.use(stdoutLog);
 		addDevLog(log);

--- a/main.js
+++ b/main.js
@@ -22,7 +22,6 @@ import { hideBin } from 'yargs/helpers';
 import {log, accessLog, stdoutLog, errorLog, addDevLog} from './logging.mjs';
 import {readSecrets} from './shakeguardSecrets.mjs';
 
-
 const argv = yargs(hideBin(process.argv))
   .option('port', {
 	  alias: 'P',
@@ -228,7 +227,7 @@ try {
 app.use(express.json());
 
 const sessionParser = session({
-	secret: "shhhh...secret",
+	secret: secrets['session.json'].sessionSecret,
 	name: "ShakeGuardSessionID",
 	store: sessionStore ?? undefined,
 	resave: false,

--- a/main.js
+++ b/main.js
@@ -250,11 +250,11 @@ app.get('/', async function (req, res) {
 	if (req.session.loggedIn) {
 		if (req.session.isAdmin) {
 			res.redirect('/dashboard');
-			return;
 		} else {
 			res.redirect('/profile');
-			return;
 		}
+		console.log("User logged in!");
+		return;
 	}
 	
 	const doc = await readFile("./html/index.html", "utf8");

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "bcrypt": "^5.0.1",
+        "connect-mongodb-session": "^3.1.1",
         "express": "^4.18.0",
         "express-session": "^1.17.2",
         "jsdom": "^19.0.0",
@@ -206,6 +207,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
+    "node_modules/archetype": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/archetype/-/archetype-0.13.0.tgz",
+      "integrity": "sha512-ts/rng/A4UQPw1ZuQWWZvR2T0q2S5+zQGBH0RPsSlmyIAsZuIGEm1rgRga2NJnHODBbW/jVWMZIWbtlEyrS7JQ==",
+      "dependencies": {
+        "lodash.clonedeep": "4.x",
+        "lodash.set": "4.x",
+        "mpath": "0.8.x"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
@@ -546,6 +560,15 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/connect-mongodb-session": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/connect-mongodb-session/-/connect-mongodb-session-3.1.1.tgz",
+      "integrity": "sha512-HBfQW7lRLb64DopgxL4Pv8/iay4HcS1WU7YJfi7B8UbBPZGzVEHx67mx8xP5c2rWUMCQ4Xi/u4GUSC7e90Hhtw==",
+      "dependencies": {
+        "archetype": "0.13.x",
+        "mongodb": "4.x"
       }
     },
     "node_modules/console-control-strings": {
@@ -1332,6 +1355,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
     "node_modules/logform": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
@@ -1551,6 +1584,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/ms": {
@@ -2733,6 +2774,16 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
     },
+    "archetype": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/archetype/-/archetype-0.13.0.tgz",
+      "integrity": "sha512-ts/rng/A4UQPw1ZuQWWZvR2T0q2S5+zQGBH0RPsSlmyIAsZuIGEm1rgRga2NJnHODBbW/jVWMZIWbtlEyrS7JQ==",
+      "requires": {
+        "lodash.clonedeep": "4.x",
+        "lodash.set": "4.x",
+        "mpath": "0.8.x"
+      }
+    },
     "are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
@@ -3006,6 +3057,15 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "connect-mongodb-session": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/connect-mongodb-session/-/connect-mongodb-session-3.1.1.tgz",
+      "integrity": "sha512-HBfQW7lRLb64DopgxL4Pv8/iay4HcS1WU7YJfi7B8UbBPZGzVEHx67mx8xP5c2rWUMCQ4Xi/u4GUSC7e90Hhtw==",
+      "requires": {
+        "archetype": "0.13.x",
+        "mongodb": "4.x"
       }
     },
     "console-control-strings": {
@@ -3610,6 +3670,16 @@
         "type-check": "~0.3.2"
       }
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
     "logform": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
@@ -3779,6 +3849,11 @@
           }
         }
       }
+    },
+    "mpath": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "type": "module",
   "dependencies": {
     "bcrypt": "^5.0.1",
+    "connect-mongodb-session": "^3.1.1",
     "express": "^4.18.0",
     "express-session": "^1.17.2",
     "jsdom": "^19.0.0",


### PR DESCRIPTION
Switches over to [`connect-mongodb-session`](https://www.npmjs.com/package/connect-mongodb-session) for storing sessions. Also adds in code for grabbing the session secret from `.secrets/session.json`.

### Advantages:
- Won't leak memory.
- Uses existing database installation, should work as long as we have one.
- Can use existing tools (e.g: MongoDB Compass, `mongosh`) to inspect sessions, should we need to.
- Sessions will persist even if the server crashes.

### Disadvantages:
- One more thing that can fail.
- Extra dependency on `connect-mongodb-session`.
- Sessions will persist even if the server crashes – debugging may be more difficult.

This PR will close #18 and #30 if it gets merged.